### PR TITLE
Add express server and API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+PORT=3001
+MONGO_URL=mongodb://localhost:27017/alya
+JWT_SECRET=your_jwt_secret

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,177 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const PORT = process.env.PORT || 3001;
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+mongoose.connect(process.env.MONGO_URL, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+// Models
+const userSchema = new mongoose.Schema({
+  name: String,
+  email: { type: String, unique: true },
+  password: String,
+});
+const User = mongoose.model('User', userSchema);
+
+const conversationSchema = new mongoose.Schema({
+  userId: mongoose.Schema.Types.ObjectId,
+  name: String,
+  messages: [
+    {
+      sender: String,
+      text: String,
+      timestamp: Date,
+      isThinking: Boolean,
+      isEdited: Boolean,
+      attachments: [String],
+    },
+  ],
+  createdAt: Date,
+  updatedAt: Date,
+  settings: {
+    enableHistory: Boolean,
+    aiModel: String,
+    temperature: Number,
+  },
+  projectId: { type: mongoose.Schema.Types.ObjectId, ref: 'Project', default: null },
+  archived: Boolean,
+});
+const Conversation = mongoose.model('Conversation', conversationSchema);
+
+const projectSchema = new mongoose.Schema({
+  userId: mongoose.Schema.Types.ObjectId,
+  name: String,
+});
+const Project = mongoose.model('Project', projectSchema);
+
+// Helpers
+function generateToken(user) {
+  return jwt.sign({ id: user._id, email: user.email }, JWT_SECRET, { expiresIn: '7d' });
+}
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ message: 'Missing token' });
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.userId = decoded.id;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+// Auth routes
+app.post('/api/signup', async (req, res) => {
+  const { name, email, password } = req.body;
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ name, email, password: hashed });
+    const token = generateToken(user);
+    res.json({ token, user: { id: user._id, name: user.name, email: user.email } });
+  } catch (err) {
+    res.status(400).json({ message: 'Signup failed', error: err.message });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const user = await User.findOne({ email });
+    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(401).json({ message: 'Invalid credentials' });
+    const token = generateToken(user);
+    res.json({ token, user: { id: user._id, name: user.name, email: user.email } });
+  } catch (err) {
+    res.status(500).json({ message: 'Login failed' });
+  }
+});
+
+app.post('/api/logout', (req, res) => {
+  res.json({ message: 'ok' });
+});
+
+// Conversations CRUD
+app.get('/api/conversations', authMiddleware, async (req, res) => {
+  const convs = await Conversation.find({ userId: req.userId });
+  res.json(convs);
+});
+
+app.post('/api/conversations', authMiddleware, async (req, res) => {
+  const convo = await Conversation.create({
+    ...req.body,
+    userId: req.userId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  res.json(convo);
+});
+
+app.get('/api/conversations/:id', authMiddleware, async (req, res) => {
+  const conv = await Conversation.findOne({ _id: req.params.id, userId: req.userId });
+  if (!conv) return res.status(404).json({ message: 'Not found' });
+  res.json(conv);
+});
+
+app.put('/api/conversations/:id', authMiddleware, async (req, res) => {
+  const conv = await Conversation.findOneAndUpdate({ _id: req.params.id, userId: req.userId }, {
+    ...req.body,
+    updatedAt: new Date(),
+  }, { new: true });
+  if (!conv) return res.status(404).json({ message: 'Not found' });
+  res.json(conv);
+});
+
+app.delete('/api/conversations/:id', authMiddleware, async (req, res) => {
+  await Conversation.deleteOne({ _id: req.params.id, userId: req.userId });
+  res.json({});
+});
+
+// Projects CRUD
+app.get('/api/projects', authMiddleware, async (req, res) => {
+  const projs = await Project.find({ userId: req.userId });
+  res.json(projs);
+});
+
+app.post('/api/projects', authMiddleware, async (req, res) => {
+  const proj = await Project.create({ userId: req.userId, ...req.body });
+  res.json(proj);
+});
+
+app.get('/api/projects/:id', authMiddleware, async (req, res) => {
+  const proj = await Project.findOne({ _id: req.params.id, userId: req.userId });
+  if (!proj) return res.status(404).json({ message: 'Not found' });
+  res.json(proj);
+});
+
+app.put('/api/projects/:id', authMiddleware, async (req, res) => {
+  const proj = await Project.findOneAndUpdate({ _id: req.params.id, userId: req.userId }, req.body, { new: true });
+  if (!proj) return res.status(404).json({ message: 'Not found' });
+  res.json(proj);
+});
+
+app.delete('/api/projects/:id', authMiddleware, async (req, res) => {
+  await Project.deleteOne({ _id: req.params.id, userId: req.userId });
+  await Conversation.updateMany({ userId: req.userId, projectId: req.params.id }, { projectId: null });
+  res.json({});
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "alya-api-server",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.6.1",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,174 +1,81 @@
 import React, { createContext, useState, useEffect } from 'react';
-    import { v4 as uuidv4 } from 'uuid';
 
-    const AuthContext = createContext();
+const AuthContext = createContext();
+const API_URL = import.meta.env.VITE_API_URL;
 
-    export const AuthProvider = ({ children }) => {
-      const [user, setUser] = useState(null);
-      const [loading, setLoading] = useState(true);
-      const [onboardingData, setOnboardingData] = useState({});
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [onboardingData, setOnboardingData] = useState({});
 
-      useEffect(() => {
-        const storedUser = localStorage.getItem('alyaUser');
-        const storedOnboardingData = localStorage.getItem('alyaOnboardingData');
-        
-        if (storedUser) {
-          setUser(JSON.parse(storedUser));
-        }
-        if (storedOnboardingData) {
-          setOnboardingData(JSON.parse(storedOnboardingData));
-        }
-        setLoading(false);
-      }, []);
+  useEffect(() => {
+    const stored = localStorage.getItem('alyaSession');
+    if (stored) {
+      const { user: u, token: t } = JSON.parse(stored);
+      setUser(u);
+      setToken(t);
+    }
+    setLoading(false);
+  }, []);
 
-      const login = (email, password) => {
-        setLoading(true);
-        return new Promise((resolve, reject) => {
-          setTimeout(() => {
-            const storedUsers = JSON.parse(localStorage.getItem('alyaRegisteredUsers') || '[]');
-            const foundUser = storedUsers.find(u => u.email === email && u.password === password);
+  const login = async (email, password) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      setUser(data.user);
+      setToken(data.token);
+      localStorage.setItem('alyaSession', JSON.stringify({ user: data.user, token: data.token }));
+      setLoading(false);
+      return data.user;
+    } catch (err) {
+      setLoading(false);
+      throw err;
+    }
+  };
 
-            if (foundUser) {
-              const userData = { 
-                id: foundUser.id, 
-                email: foundUser.email, 
-                name: foundUser.name || 'Utilisateur Alya', 
-                avatarUrl: foundUser.avatarUrl || `https://avatar.vercel.sh/${foundUser.email}.png?size=128`,
-                onboardingCompleted: foundUser.onboardingCompleted || false,
-                preferences: foundUser.preferences || {}
-              };
-              setUser(userData);
-              localStorage.setItem('alyaUser', JSON.stringify(userData));
-              
-              // Load specific onboarding data for this user
-              const userOnboardingKey = `alyaOnboardingData_${foundUser.id}`;
-              const storedUserOnboardingData = localStorage.getItem(userOnboardingKey);
-              if (storedUserOnboardingData) {
-                setOnboardingData(JSON.parse(storedUserOnboardingData));
-              } else {
-                setOnboardingData(userData.preferences || {}); // Fallback to general preferences if specific onboarding data is missing
-              }
+  const signup = async (name, email, password) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/api/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password })
+      });
+      if (!res.ok) throw new Error('Signup failed');
+      const data = await res.json();
+      setUser(data.user);
+      setToken(data.token);
+      localStorage.setItem('alyaSession', JSON.stringify({ user: data.user, token: data.token }));
+      setLoading(false);
+      return data.user;
+    } catch (err) {
+      setLoading(false);
+      throw err;
+    }
+  };
 
-              setLoading(false);
-              resolve(userData);
-            } else {
-              setLoading(false);
-              reject(new Error("Email ou mot de passe incorrect."));
-            }
-          }, 1000);
-        });
-      };
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('alyaSession');
+  };
 
-      const signup = (name, email, password) => {
-        setLoading(true);
-        return new Promise((resolve, reject) => {
-          setTimeout(() => {
-            let storedUsers = JSON.parse(localStorage.getItem('alyaRegisteredUsers') || '[]');
-            if (storedUsers.find(u => u.email === email)) {
-              setLoading(false);
-              reject(new Error("Un compte avec cet email existe déjà."));
-              return;
-            }
+  const isOnboardingCompleted = () => {
+    return user ? user.onboardingCompleted : false;
+  };
 
-            const newUser = { 
-              id: uuidv4(), 
-              name, 
-              email, 
-              password, // In a real app, hash the password
-              avatarUrl: `https://avatar.vercel.sh/${email}.png?size=128`,
-              onboardingCompleted: false,
-              preferences: {} // Initialize empty preferences
-            };
-            storedUsers.push(newUser);
-            localStorage.setItem('alyaRegisteredUsers', JSON.stringify(storedUsers));
-            
-            const userData = { ...newUser };
-            delete userData.password; // Don't store password in active user state
+  return (
+    <AuthContext.Provider value={{ user, token, loading, login, signup, logout, onboardingData, isOnboardingCompleted }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
 
-            setUser(userData);
-            localStorage.setItem('alyaUser', JSON.stringify(userData));
-            setOnboardingData({}); // Reset onboarding data for new user
-            const userOnboardingKey = `alyaOnboardingData_${newUser.id}`;
-            localStorage.setItem(userOnboardingKey, JSON.stringify({}));
-
-
-            setLoading(false);
-            resolve(userData);
-          }, 1000);
-        });
-      };
-
-      const logout = () => {
-        setUser(null);
-        setOnboardingData({});
-        localStorage.removeItem('alyaUser');
-        // Don't remove alyaOnboardingData globally, it might be for other users.
-        // Specific user onboarding data is keyed by user ID.
-      };
-
-      const updateUserProfile = (profileData) => {
-         setLoading(true);
-        return new Promise((resolve, reject) => {
-          setTimeout(() => {
-            if (!user) {
-              setLoading(false);
-              reject(new Error("Aucun utilisateur connecté."));
-              return;
-            }
-            const updatedUser = { ...user, ...profileData };
-            
-            // If onboarding is completed, merge onboardingData into preferences
-            if (profileData.onboardingCompleted === true && !user.onboardingCompleted) {
-                const finalPreferences = { ...user.preferences, ...onboardingData };
-                updatedUser.preferences = finalPreferences;
-                // Persist these final preferences to the registered user list as well
-                 let storedUsers = JSON.parse(localStorage.getItem('alyaRegisteredUsers') || '[]');
-                 storedUsers = storedUsers.map(u => u.id === user.id ? { ...u, ...updatedUser, preferences: finalPreferences, password: u.password } : u);
-                 localStorage.setItem('alyaRegisteredUsers', JSON.stringify(storedUsers));
-            }
-
-
-            setUser(updatedUser);
-            localStorage.setItem('alyaUser', JSON.stringify(updatedUser));
-
-            // Update in registered users list as well
-            let storedUsers = JSON.parse(localStorage.getItem('alyaRegisteredUsers') || '[]');
-            storedUsers = storedUsers.map(u => {
-              if (u.id === user.id) {
-                const { password, ...restOfUser } = u; // Keep original password
-                return { ...restOfUser, ...updatedUser, password };
-              }
-              return u;
-            });
-            localStorage.setItem('alyaRegisteredUsers', JSON.stringify(storedUsers));
-            
-            setLoading(false);
-            resolve(updatedUser);
-          }, 500);
-        });
-      };
-      
-      const updateOnboardingData = (newDataStep) => {
-        setOnboardingData(prevData => {
-          const updatedData = { ...prevData, ...newDataStep };
-          if (user) {
-            const userOnboardingKey = `alyaOnboardingData_${user.id}`;
-            localStorage.setItem(userOnboardingKey, JSON.stringify(updatedData));
-          }
-          return updatedData;
-        });
-      };
-
-      const isOnboardingCompleted = () => {
-        return user ? user.onboardingCompleted : false;
-      };
-
-
-      return (
-        <AuthContext.Provider value={{ user, loading, login, signup, logout, updateUserProfile, onboardingData, updateOnboardingData, isOnboardingCompleted }}>
-          {children}
-        </AuthContext.Provider>
-      );
-    };
-
-    export default AuthContext;
+export default AuthContext;


### PR DESCRIPTION
## Summary
- set up server directory with Express and Mongoose
- add auth, conversation and project endpoints
- create env examples for client and server
- switch AuthContext and ChatContext to use API calls

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688be6959c888331a676a786d4bb46f4