### PR TITLE
Add environment variable templates and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_API_URL=http://localhost:3000/api
+DB_URL=postgresql://user:password@localhost:5432/database
+JWT_SECRET=your_jwt_secret_here

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Environment Variables
+
+Create a `.env` file based on `.env.example` and provide values for the following keys:
+
+- `VITE_API_URL` - Base URL used for API requests, e.g. `http://localhost:3000/api`.
+- `DB_URL` - Connection string for the database, e.g. `postgresql://user:password@localhost:5432/database`.
+- `JWT_SECRET` - Secret value used to sign JWT tokens.

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+export const API_URL = import.meta.env.VITE_API_URL;
+export const DB_URL = import.meta.env.DB_URL;
+export const JWT_SECRET = import.meta.env.JWT_SECRET;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useState, useEffect } from 'react';
-    import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
+import { API_URL, DB_URL, JWT_SECRET } from '@/config';
 
     const AuthContext = createContext();
 
@@ -9,6 +10,7 @@ import React, { createContext, useState, useEffect } from 'react';
       const [onboardingData, setOnboardingData] = useState({});
 
       useEffect(() => {
+        console.debug('Loaded env vars', { API_URL, DB_URL, JWT_SECRET });
         const storedUser = localStorage.getItem('alyaUser');
         const storedOnboardingData = localStorage.getItem('alyaOnboardingData');
         


### PR DESCRIPTION
## Summary
- add `.env.example` with API, DB and JWT variables
- document the env vars in README
- expose env vars in `src/config.js`
- log env vars in `AuthContext` for demonstration

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688be69d64488331b7cacb0ea404de1e