### PR TITLE
Fix server MongoDB connect

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -14,10 +14,12 @@ app.use(express.json());
 const PORT = process.env.PORT || 3001;
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
-mongoose.connect(process.env.MONGO_URL, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
+if (process.env.MONGO_URL && process.env.NODE_ENV !== 'test') {
+  mongoose.connect(process.env.MONGO_URL, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+}
 
 // Models
 const userSchema = new mongoose.Schema({


### PR DESCRIPTION
## Summary
- avoid connection attempt when running tests by checking `NODE_ENV`

## Testing
- `npm test` *(fails: signup API test returns 400)*

------
https://chatgpt.com/codex/tasks/task_e_688c0562a3788331976b761a0e96eed3